### PR TITLE
Avoid compile error

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -207,47 +207,46 @@ For cc-mode support within color-identifiers-mode."
                 "[a-zA-Z_$]\\(\\s_\\|\\sw\\)*\\s-*[(:]")))
 
 ;; Python
-(defun color-identifiers:python-get-declarations ()
-  "Extract a list of identifiers declared in the current buffer.
+(when (fboundp 'python-nav-forward-defun)
+  (defun color-identifiers:python-get-declarations ()
+    "Extract a list of identifiers declared in the current buffer.
 For Python support within color-identifiers-mode.  Supports
 function arguments and variable assignment, but not yet lambda
 arguments, loops (for .. in), or for comprehensions."
-  (let ((result nil))
-    ;; Function arguments
-    (save-excursion
-      (goto-char (point-min))
-      (while (python-nav-forward-defun)
-        (let ((arglist (sexp-at-point)))
-          (when (and arglist (listp arglist))
-            (let* ((first-arg (car arglist))
-                   (rest (cdr arglist))
-                   (rest-args
-                    (-map (lambda (token) (cadr token))
-                          (-filter (lambda (token) (and (listp token) (eq (car token) '\,))) rest)))
-                   (args-filtered (cons first-arg rest-args))
-                   (params (-map (lambda (token)
-                                   (car (split-string (symbol-name token) "=")))
-                                 args-filtered)))
-              (setq result (append params result)))))))
-    ;; Variables that python-mode highlighted with font-lock-variable-name-face
-    (save-excursion
-      (goto-char (point-min))
-      (catch 'end-of-file
-        (while t
-          (let ((next-change (next-property-change (point))))
-            (if (not next-change)
-                (throw 'end-of-file nil)
-              (goto-char next-change)
-              (when (or (eq (get-text-property (point) 'face) 'font-lock-variable-name-face)
-                        ;; If we fontified it in the past, assume it should
-                        ;; continue to be fontified. This avoids alternating
-                        ;; between fontified and unfontified.
-                        (get-text-property (point) 'color-identifiers:fontified))
-                (push (substring-no-properties (symbol-name (symbol-at-point))) result)))))))
-    (delete-dups result)
-    result))
-
-(when (fboundp 'python-nav-forward-defun)
+    (let ((result nil))
+      ;; Function arguments
+      (save-excursion
+        (goto-char (point-min))
+        (while (python-nav-forward-defun)
+          (let ((arglist (sexp-at-point)))
+            (when (and arglist (listp arglist))
+              (let* ((first-arg (car arglist))
+                     (rest (cdr arglist))
+                     (rest-args
+                      (-map (lambda (token) (cadr token))
+                            (-filter (lambda (token) (and (listp token) (eq (car token) '\,))) rest)))
+                     (args-filtered (cons first-arg rest-args))
+                     (params (-map (lambda (token)
+                                     (car (split-string (symbol-name token) "=")))
+                                   args-filtered)))
+                (setq result (append params result)))))))
+      ;; Variables that python-mode highlighted with font-lock-variable-name-face
+      (save-excursion
+        (goto-char (point-min))
+        (catch 'end-of-file
+          (while t
+            (let ((next-change (next-property-change (point))))
+              (if (not next-change)
+                  (throw 'end-of-file nil)
+                (goto-char next-change)
+                (when (or (eq (get-text-property (point) 'face) 'font-lock-variable-name-face)
+                          ;; If we fontified it in the past, assume it should
+                          ;; continue to be fontified. This avoids alternating
+                          ;; between fontified and unfontified.
+                          (get-text-property (point) 'color-identifiers:fontified))
+                  (push (substring-no-properties (symbol-name (symbol-at-point))) result)))))))
+      (delete-dups result)
+      result))
   (color-identifiers:set-declaration-scan-fn
    'python-mode 'color-identifiers:python-get-declarations))
 


### PR DESCRIPTION
Without `python-nav-forward-defun`, it causes compile error and won't work properly.
