### PR TITLE
Add trivial OCaml/SML support

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -431,6 +431,14 @@ incompatible with Emacs Lisp syntax, such as reader macros (#)."
                    "\\_<\\(\\(?:\\s_\\|\\sw\\)+\\)"
                    (nil))))
 
+(dolist (maj-mode '(tuareg-mode sml-mode))
+  (color-identifiers:set-declaration-scan-fn
+   maj-mode 'color-identifiers:cc-mode-get-declarations)
+  (add-to-list
+   'color-identifiers:modes-alist
+   `(,maj-mode . (""
+                  "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\|'\\)*\\)"
+                  (nil font-lock-variable-name-face)))))
 
 ;;; PACKAGE INTERNALS ==========================================================
 


### PR DESCRIPTION
I've been using this for a little while in OCaml and SML buffers.  If you have any suggestions for improving it, please let me know.  I'm not sure if it's kosher for me to use `cc-mode-get-declarations` here.