### PR TITLE
Change `evenp` -> `cl-evenp` in Clojure mode code

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -39,6 +39,7 @@
 (require 'color)
 (require 'dash)
 (require 'python)
+(require 'cl-lib)
 
 (defvar color-identifiers:timer)
 
@@ -382,7 +383,7 @@ For Clojure support within color-identifiers-mode. "
      (append (when (sequencep (car rest))
                (let* ((bindings (append (car rest) nil))
                       (even-indices
-                       (-filter 'evenp (number-sequence 0 (1- (length bindings)))))
+                       (-filter 'cl-evenp (number-sequence 0 (1- (length bindings)))))
                       (binding-forms (-select-by-indices even-indices bindings)))
                  (color-identifiers:clojure-extract-params binding-forms)))
              (color-identifiers:clojure-declarations-in-sexp rest)))


### PR DESCRIPTION
When running on a recent version of emacs it appears `evenp` is no longer recognised (probably because namespaces were introduced?)

This fix requires the common lisp library and tweaks the `evenp` call to refer to `cl-evenp`.