### PR TITLE
Add rust-mode to supported langs

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -175,7 +175,7 @@ For cc-mode support within color-identifiers-mode."
     (delete-dups result)
     result))
 
-(dolist (maj-mode '(c-mode c++-mode java-mode))
+(dolist (maj-mode '(c-mode c++-mode java-mode rust-mode))
   (color-identifiers:set-declaration-scan-fn
    maj-mode 'color-identifiers:cc-mode-get-declarations)
   (add-to-list


### PR DESCRIPTION
It relies upon font-lock-variable-name-face being set by rust-mode.
Note: the support into rust-mode was added just recently (at
rust-lang/rust-mode#225), so make sure to have
recent enough version (MELPA has already updated the rust-mode).

Signed-off-by: Constantine Kharlamov <Hi-Angel@yandex.ru>