### PR TITLE
Do not change colors of already colored variables v2

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -651,10 +651,14 @@ major mode, identifiers are saved to
     (cond
      ((eq color-identifiers-coloring-method 'sequential)
       (setq color-identifiers:color-index-for-identifier
-            (-map-indexed
-             (lambda (i identifier)
-               (cons identifier (% i color-identifiers:num-colors)))
-             (color-identifiers:list-identifiers))))
+            (append (-map-indexed
+                     (lambda (i identifier)
+                       (cons identifier (% i color-identifiers:num-colors)))
+                     (-filter (lambda (e)
+                                (cl-notany (lambda (d) (equal e (car d)))
+                                           color-identifiers:color-index-for-identifier))
+                              (color-identifiers:list-identifiers)))
+                    color-identifiers:color-index-for-identifier)))
      ((and (eq color-identifiers-coloring-method 'hash)
            (color-identifiers:get-declaration-scan-fn major-mode))
       (setq color-identifiers:identifiers

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -653,7 +653,8 @@ major mode, identifiers are saved to
       (setq color-identifiers:color-index-for-identifier
             (append (-map-indexed
                      (lambda (i identifier)
-                       (cons identifier (% i color-identifiers:num-colors)))
+                       ;; to make sure subsequently added vars aren't colorized the same add a (point)
+                       (cons identifier (% (+ (point) i) color-identifiers:num-colors)))
                      (-filter (lambda (e)
                                 (cl-notany (lambda (d) (equal e (car d)))
                                            color-identifiers:color-index-for-identifier))


### PR DESCRIPTION
Should fix [the bug reported](https://github.com/ankurdave/color-identifiers-mode/issues/22#issuecomment-69896023) by @roobie *(note: I'm referring to a comment, please don't close whole issue)*.

I also suspect that some modes I have enabled could've triggered re-fontification more often, that would explain why I met the problem more often than other peoples.

v2: changed the branch of the PR so that the time review takes wouldn't inhibit further development.