### PR TITLE
Keep colored syntax in unsupported modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,18 +39,21 @@ If you like it, enable it for all supported files by adding the following to you
 
 ## Extras
 
-To make the variables stand out, you can turn off highlighting for all other keywords using code similar to the following:
+To make the variables stand out, you can turn off highlighting for all other keywords in supported modes using a code like:
 ```lisp
-(let ((faces '(font-lock-comment-face font-lock-comment-delimiter-face font-lock-constant-face font-lock-type-face font-lock-function-name-face font-lock-variable-name-face font-lock-keyword-face font-lock-string-face font-lock-builtin-face font-lock-preprocessor-face font-lock-warning-face font-lock-doc-face)))
-  (dolist (face faces)
-    (set-face-attribute face nil :foreground nil :weight 'normal :slant 'normal)))
-
-(set-face-attribute 'font-lock-comment-delimiter-face nil :slant 'italic)
-(set-face-attribute 'font-lock-comment-face nil :slant 'italic)
-(set-face-attribute 'font-lock-doc-face nil :slant 'italic)
-(set-face-attribute 'font-lock-keyword-face nil :weight 'bold)
-(set-face-attribute 'font-lock-builtin-face nil :weight 'bold)
-(set-face-attribute 'font-lock-preprocessor-face nil :weight 'bold)
+(defun myfunc-color-identifiers-mode-hook ()
+  (let ((faces '(font-lock-type-face font-lock-function-name-face font-lock-variable-name-face font-lock-keyword-face font-lock-builtin-face font-lock-preprocessor-face font-lock-constant-face)))
+    (dolist (face faces)
+      (face-remap-add-relative face '((:foreground "" :weight normal :slant normal)))))
+  (face-remap-add-relative 'font-lock-keyword-face '((:weight bold)))
+  (face-remap-add-relative 'font-lock-builtin-face '((:weight bold)))
+  (face-remap-add-relative 'font-lock-preprocessor-face '((:weight bold)))
+  (face-remap-add-relative 'font-lock-function-name-face '((:weight bold)))
+  (face-remap-add-relative 'font-lock-string-face '((:foreground "#b33200000000")))
+  (face-remap-add-relative 'font-lock-constant-face '((:weight bold)))
+  (face-remap-add-relative 'haskell-operator-face '((:foreground "#b33200000000")))
+  )
+(add-hook 'color-identifiers-mode-hook 'myfunc-color-identifiers-mode-hook)
 ```
 
 ![Other Keywords Dimmed](https://raw.github.com/ankurdave/color-identifiers-mode/gh-pages/dim-other-keywords.png)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Color Identifiers Mode
 Color Identifiers is a minor mode for Emacs that highlights each source code identifier uniquely based on its name. It is inspired by a [post by Evan Brooks](https://medium.com/p/3a6db2743a1e/).
 
-Currently it supports Scala (scala-mode2), JavaScript (js-mode and js2-mode), Ruby, Python, Emacs Lisp, Clojure, C, C++, and Java. You can add support for your favorite mode by modifying `color-identifiers:modes-alist` and optionally calling `color-identifiers:set-declaration-scan-fn`.
+Currently it supports Scala (scala-mode2), JavaScript (js-mode and js2-mode), Ruby, Python, Emacs Lisp, Clojure, C, C++, Rust, and Java. You can add support for your favorite mode by modifying `color-identifiers:modes-alist` and optionally calling `color-identifiers:set-declaration-scan-fn`.
 
 [Check out the demo.](http://youtu.be/g4qsiAo2aac)
 

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -63,7 +63,8 @@
       (cancel-timer color-identifiers:timer))
     (setq color-identifiers:timer nil)
     (font-lock-remove-keywords nil '((color-identifiers:colorize . default)))
-    (ad-deactivate 'enable-theme))
+    (ad-deactivate 'enable-theme)
+    (run-hooks 'color-identifiers-mode-hook))
   (color-identifiers:refontify))
 
 ;;;###autoload
@@ -127,6 +128,9 @@ candidates matching the constraints in
 
 Modify this variable using
 `color-identifiers:set-declaration-scan-fn'.")
+
+(defvar color-identifiers-mode-hook nil
+  "List of functions to run every time the mode enabled")
 
 (defun color-identifiers:set-declaration-scan-fn (mode scan-fn)
   "Register SCAN-FN as the declaration scanner for MODE.


### PR DESCRIPTION
It's usually unwanted to turn off syntax coloring in irrelevant modes, like markdown, html, other markup modes, unsupported langs…

The first 2 patches allows to limit turned off colors to supported modes. It should not cause regressions for those keeping to unset faces globally, because it's basically adding a hook, and a documentation change. I left so far in the commit the link to discussion behind empty string versus nil, I am unsure whether it's worth putting to a comment.

3-rd patch is irrelevant trivia.