### PR TITLE
fix srgb conversion to hex when negative numbers are involved

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -613,7 +613,9 @@ Colors are output to `color-identifiers:colors'."
           (funcall choose-candidate (car best))))
       (setq color-identifiers:colors
             (-map (lambda (lab)
-                    (apply 'color-rgb-to-hex (apply 'color-lab-to-srgb lab)))
+                    (let* ((srgb (apply 'color-lab-to-srgb lab))
+                           (rgb (mapcar 'color-clamp srgb)))
+                      (apply 'color-rgb-to-hex rgb)))
                   chosens)))))
 
 (defvar color-identifiers:color-index-for-identifier nil


### PR DESCRIPTION
Works around #55 

The function `color-rgb-to-hex` raises an error when negative values are passed, on Git Emacs.
In the default configuration, these negatives seem to be values under 10^-4 when they occur.
Negative RGB components do not make much sense anyway, so I propose a modification to replace them with 0 values.