### PR TITLE
Feature: Customization to set custom faces to be avoided when generating color 

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -86,6 +86,15 @@ across buffers."
           (const :tag "Sequential" sequential)
           (const :tag "Hash-based" hash)))
 
+
+(defcustom color-identifiers-avoid-faces nil
+  "How to assign colors: sequentially or using the hash of the identifier.
+Sequential color assignment (the default) reduces collisions
+between adjacent identifiers. Hash-based color assignment ensures
+that a particular identifier is always assigned the same color
+across buffers."
+  :type '(alist :value-type (face)))
+
 (defvar color-identifiers:modes-alist nil
   "Alist of major modes and the ways to distinguish identifiers in those modes.
 The value of each cons cell provides four constraints for finding identifiers.

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -591,6 +591,7 @@ Colors are output to `color-identifiers:colors'."
          (min-saturation (float color-identifiers:min-color-saturation))
          (saturation-range (- (float color-identifiers:max-color-saturation) min-saturation))
          (bgcolor (color-identifiers:attribute-lab :background))
+         (blocklist (mapcar color-identifiers:foreground-lab color-identifiers-avoid-faces))
          (candidates '())
          (chosens '())
          (n 8)
@@ -615,7 +616,7 @@ Colors are output to `color-identifiers:colors'."
                                   (cons candidate
                                         (-min (-map (lambda (chosen)
                                                       (color-cie-de2000 candidate chosen))
-                                                    (cons bgcolor chosens)))))
+                                                    (cons bgcolor (append chosens blocklist))))))
                                 candidates))
                ;; Take the candidate with the highest min distance
                (best (-max-by (lambda (x y) (> (cdr x) (cdr y))) min-dists)))
@@ -650,6 +651,14 @@ mode. This variable memoizes the result of the declaration scan function.")
 (defun color-identifiers:attribute-lab (attribute)
   "Find the LAB color value of the specified ATTRIBUTE on the default face."
   (let ((rgb (color-name-to-rgb (face-attribute 'default attribute))))
+    (if rgb
+        (apply 'color-srgb-to-lab rgb)
+      '(0.0 0.0 0.0))))
+
+(defun color-identifiers:foreground-lab (face)
+  "Find the LAB color value of the foreground attribute on the
+specified face."
+  (let ((rgb (color-name-to-rgb (face-attribute face :foreground))))
     (if rgb
         (apply 'color-srgb-to-lab rgb)
       '(0.0 0.0 0.0))))

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -88,11 +88,9 @@ across buffers."
 
 
 (defcustom color-identifiers-avoid-faces nil
-  "How to assign colors: sequentially or using the hash of the identifier.
-Sequential color assignment (the default) reduces collisions
-between adjacent identifiers. Hash-based color assignment ensures
-that a particular identifier is always assigned the same color
-across buffers."
+  "Which color faces to avoid: A list of faces whose foreground
+color should be avoided when generating colors, this can be warning colors,
+error colors etc."
   :type '(repeat face))
 
 (defvar color-identifiers:modes-alist nil

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -93,7 +93,7 @@ Sequential color assignment (the default) reduces collisions
 between adjacent identifiers. Hash-based color assignment ensures
 that a particular identifier is always assigned the same color
 across buffers."
-  :type '(repeat :(face)))
+  :type '(repeat face))
 
 (defvar color-identifiers:modes-alist nil
   "Alist of major modes and the ways to distinguish identifiers in those modes.

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -93,7 +93,7 @@ Sequential color assignment (the default) reduces collisions
 between adjacent identifiers. Hash-based color assignment ensures
 that a particular identifier is always assigned the same color
 across buffers."
-  :type '(alist :value-type (face)))
+  :type '(repeat :(face)))
 
 (defvar color-identifiers:modes-alist nil
   "Alist of major modes and the ways to distinguish identifiers in those modes.

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -591,7 +591,7 @@ Colors are output to `color-identifiers:colors'."
          (min-saturation (float color-identifiers:min-color-saturation))
          (saturation-range (- (float color-identifiers:max-color-saturation) min-saturation))
          (bgcolor (color-identifiers:attribute-lab :background))
-         (blocklist (mapcar color-identifiers:foreground-lab color-identifiers-avoid-faces))
+         (blocklist (mapcar 'color-identifiers:foreground-lab color-identifiers-avoid-faces))
          (candidates '())
          (chosens '())
          (n 8)

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -589,7 +589,7 @@ Colors are output to `color-identifiers:colors'."
          (min-saturation (float color-identifiers:min-color-saturation))
          (saturation-range (- (float color-identifiers:max-color-saturation) min-saturation))
          (bgcolor (color-identifiers:attribute-lab :background))
-         (blocklist (mapcar 'color-identifiers:foreground-lab color-identifiers-avoid-faces))
+         (avoidlist (mapcar 'color-identifiers:foreground-lab color-identifiers-avoid-faces))
          (candidates '())
          (chosens '())
          (n 8)
@@ -614,7 +614,7 @@ Colors are output to `color-identifiers:colors'."
                                   (cons candidate
                                         (-min (-map (lambda (chosen)
                                                       (color-cie-de2000 candidate chosen))
-                                                    (cons bgcolor (append chosens blocklist))))))
+                                                    (cons bgcolor (append chosens avoidlist))))))
                                 candidates))
                ;; Take the candidate with the highest min distance
                (best (-max-by (lambda (x y) (> (cdr x) (cdr y))) min-dists)))


### PR DESCRIPTION
**Change**
- Previously colors when generated using algorithm and there was not custom setting to avoid some color
- Now we can set a custom variable color-identifiers-avoid-faces to avoid certain faces which we believe represent some other meaning in our context

**Issue**
#59 