### PR TITLE
color-identifiers-mode.el: limit (looking-back) with line beginning

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -766,7 +766,7 @@ evaluates to true."
                              (and flface-prop (memq flface-prop identifier-faces)))
                            (get-text-property (point) 'color-identifiers:fontified)))
                   (goto-char (next-property-change (point) nil limit))
-                (if (not (and (looking-back identifier-context-re nil)
+                (if (not (and (looking-back identifier-context-re (line-beginning-position))
                               (or (not identifier-exclusion-re) (not (looking-at identifier-exclusion-re)))
                               (looking-at identifier-re)))
                     (progn


### PR DESCRIPTION
`(looking-back)` function has bad performance, which is explicitly documented. So
it's better to limit its use, either in general, or at least to a portion of buffer.

In my tests, search operations on Python buffers resulted in big CPU
load, which I tracked down to `(looking-back)` function. Limiting
the call with beginning of the buffer improved time a lot.

For testing I searched `not_found_message` in `interpetator.py` file of
meson, and measured time of `(color-identifiers:scan-identifiers)`
function.

Before:

    (0.000129431 0 0.0)
    (0.001869894 0 0.0)
    (0.001798768 0 0.0)
    (0.001853524 0 0.0)
    (0.002508738 0 0.0)
    (0.005276375 0 0.0)
    (0.004376699 0 0.0)
    (0.004512336 0 0.0)
    (0.004265427 0 0.0)
    (0.008791819 0 0.0)
    (0.00790308 0 0.0)
    (0.549390703 0 0.0)
    (0.330451611 0 0.0)
    (0.48631925 0 0.0)
    (0.032972452 0 0.0)
    (0.273051493 0 0.0)
    (0.104208415 0 0.0)

After:

    (8.4067e-05 0 0.0)
    (0.001115394 0 0.0)
    (0.000975669 0 0.0)
    (0.001217772 0 0.0)
    (0.002791122 0 0.0)
    (0.002674071 0 0.0)
    (0.002754122 0 0.0)
    (0.001712691 0 0.0)
    (0.000947949 0 0.0)
    (0.000735731 0 0.0)
    (0.001101217 0 0.0)
    (0.001080936 0 0.0)
    (0.000826694 0 0.0)
    (0.000825475 0 0.0)
    (0.000113389 0 0.0)
    (0.001007357 0 0.0)
    (0.001217875 0 0.0)

Signed-off-by: Konstantin Kharlamov <Hi-Angel@yandex.ru>
