### PR TITLE
color-identifiers-mode.el: add support for meson-mode

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -189,7 +189,7 @@ For cc-mode support within color-identifiers-mode."
     (delete-dups result)
     result))
 
-(dolist (maj-mode '(c-mode c++-mode java-mode rust-mode))
+(dolist (maj-mode '(c-mode c++-mode java-mode rust-mode meson-mode))
   (color-identifiers:set-declaration-scan-fn
    maj-mode 'color-identifiers:cc-mode-get-declarations)
   (add-to-list


### PR DESCRIPTION
This adds support for meson-mode, a mode for Meson build system.

Note that meson-mode has [only recently started assigning a `font-lock-variable-name-face` to variables](https://github.com/wentasah/meson-mode/pull/20).