### PR TITLE
Highlight identifiers on start of line 

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -40,6 +40,7 @@
 (require 'dash)
 (require 'python)
 (require 'cl-lib)
+(require 'rx)
 
 (defgroup color-identifiers nil "Color identifiers based on their names."
   :group 'faces)
@@ -330,7 +331,8 @@ arguments, loops (for .. in), or for comprehensions."
 
 (add-to-list
  'color-identifiers:modes-alist
- `(python-mode . ("[^.][[:space:]]*"
+ `(python-mode . (,(rx (or (not (any ".")) line-start)
+                       (zero-or-more space))
                   "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)"
                   (nil font-lock-type-face font-lock-variable-name-face))))
 

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -101,9 +101,10 @@ error colors etc."
   "Alist of major modes and the ways to distinguish identifiers in those modes.
 The value of each cons cell provides four constraints for finding identifiers.
 A word must match all four constraints to be colored as an identifier.  The
-value has the form (IDENTIFIER-CONTEXT-RE IDENTIFIER-RE IDENTIFIER-FACES
+cons cell has the form (MAJOR-MODE IDENTIFIER-CONTEXT-RE IDENTIFIER-RE IDENTIFIER-FACES
 IDENTIFIER-EXCLUSION-RE).
 
+MAJOR-MODE is the name of the mode in which this rule should be used.
 IDENTIFIER-CONTEXT-RE is a regexp matching the text that must precede an
 identifier.
 IDENTIFIER-RE is a regexp whose first capture group matches identifiers.

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -144,6 +144,12 @@ Modify this variable using
 (defvar color-identifiers-mode-hook nil
   "List of functions to run every time the mode enabled")
 
+(defvar color-identifiers:re-not-inside-class-access
+  (rx (or (not (any ".")) line-start)
+      (zero-or-more space))
+  "This regexp matches anything except inside a class instance
+  access, like foo.bar" )
+
 (defun color-identifiers:set-declaration-scan-fn (mode scan-fn)
   "Register SCAN-FN as the declaration scanner for MODE.
 SCAN-FN must scan the entire current buffer and return the
@@ -164,7 +170,7 @@ SCAN-FN."
 ;; Scala
 (add-to-list
  'color-identifiers:modes-alist
- `(scala-mode . ("[^.][[:space:]]*"
+ `(scala-mode . (,color-identifiers:re-not-inside-class-access
                  "\\_<\\([[:lower:]]\\([_]??[[:lower:][:upper:]\\$0-9]+\\)*\\(_+[#:<=>@!%&*+/?\\\\^|~-]+\\|_\\)?\\)"
                  (nil scala-font-lock:var-face font-lock-variable-name-face))))
 
@@ -203,31 +209,31 @@ For cc-mode support within color-identifiers-mode."
 ;;; JavaScript
 (add-to-list
  'color-identifiers:modes-alist
- `(js-mode . ("[^.][[:space:]]*"
+ `(js-mode . (,color-identifiers:re-not-inside-class-access
               "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)"
               (nil font-lock-variable-name-face))))
 
 (add-to-list
  'color-identifiers:modes-alist
- `(js2-mode . ("[^.][[:space:]]*"
+ `(js2-mode . (,color-identifiers:re-not-inside-class-access
                "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)"
                (nil font-lock-variable-name-face js2-function-param))))
 
 (add-to-list
  'color-identifiers:modes-alist
- `(js3-mode . ("[^.][[:space:]]*"
+ `(js3-mode . (,color-identifiers:re-not-inside-class-access
                "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)"
                (nil font-lock-variable-name-face js3-function-param-face))))
 
 (add-to-list
  'color-identifiers:modes-alist
- `(js-jsx-mode . ("[^.][[:space:]]*"
+ `(js-jsx-mode . (,color-identifiers:re-not-inside-class-access
                   "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)"
                   (nil font-lock-variable-name-face js2-function-param))))
 
 (add-to-list
  'color-identifiers:modes-alist
- `(js2-jsx-mode . ("[^.][[:space:]]*"
+ `(js2-jsx-mode . (,color-identifiers:re-not-inside-class-access
                    "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)"
                    (nil font-lock-variable-name-face js2-function-param))))
 
@@ -236,7 +242,7 @@ For cc-mode support within color-identifiers-mode."
 ;; (add-hook 'coffee-mode-hook (lambda () (modify-syntax-entry ?\@ "_"))) in .emacs
 (add-to-list
  'color-identifiers:modes-alist
- `(coffee-mode . ("[^.][[:space:]]*" "\\_<\\([a-zA-Z_$@]\\(?:\\s_\\|\\sw\\)*\\)" (nil font-lock-variable-name-face))))
+ `(coffee-mode . (,color-identifiers:re-not-inside-class-access "\\_<\\([a-zA-Z_$@]\\(?:\\s_\\|\\sw\\)*\\)" (nil font-lock-variable-name-face))))
 
 ;; Sgml mode and the like
 (dolist (maj-mode '(sgml-mode html-mode jinja2-mode))
@@ -249,22 +255,22 @@ For cc-mode support within color-identifiers-mode."
 ;; Ruby
 (add-to-list
  'color-identifiers:modes-alist
- `(ruby-mode . ("[^.][[:space:]]*" "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)" (nil))))
+ `(ruby-mode . (,color-identifiers:re-not-inside-class-access "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)" (nil))))
 
 ;; R
 (add-to-list
  'color-identifiers:modes-alist
- `(R-mode . ("[^.][[:space:]]*" "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)" (nil))))
+ `(R-mode . (,color-identifiers:re-not-inside-class-access "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)" (nil))))
 
 ;; SQL
 (add-to-list
  'color-identifiers:modes-alist
- `(sql-mode . ("[^.][[:space:]]*" "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)" (nil))))
+ `(sql-mode . (,color-identifiers:re-not-inside-class-access "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)" (nil))))
 
 ;; Groovy
 (add-to-list
  'color-identifiers:modes-alist
- `(groovy-mode . ("[^.][[:space:]]*"
+ `(groovy-mode . (,color-identifiers:re-not-inside-class-access
                   "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)"
                   (nil font-lock-variable-name-face))))
 
@@ -279,7 +285,7 @@ For cc-mode support within color-identifiers-mode."
 ;; Golang
 (add-to-list
  'color-identifiers:modes-alist
- `(go-mode . ("[^.][[:space:]]*"
+ `(go-mode . (,color-identifiers:re-not-inside-class-access
               "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)"
               (nil font-lock-variable-name-face))))
 
@@ -331,8 +337,7 @@ arguments, loops (for .. in), or for comprehensions."
 
 (add-to-list
  'color-identifiers:modes-alist
- `(python-mode . (,(rx (or (not (any ".")) line-start)
-                       (zero-or-more space))
+ `(python-mode . (,color-identifiers:re-not-inside-class-access
                   "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)"
                   (nil font-lock-type-face font-lock-variable-name-face))))
 


### PR DESCRIPTION
The 1st commit is just a fix to docs. I took me quite some time to figure out why does `(nth 0 color-identifiers:modes-alist)` give me a list where first element is not a regular expression, as opposed to what documentation says. So here's a fix.

The 2nd commit fixes the problem that in Python mode identifiers starting right at the beginning of a line were not getting highlighted.

It turns out, the same regular expression that the 2nd commit fixes was used for many other languages. I guess nobody noticed that because I doubt in langs other than python an identifier happens to be at the beginning of a line too often. Either way, 3rd commit fixes the rest of regexes.