### PR TITLE
color-identifiers-mode.el: python, highlight typed function args

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -309,7 +309,7 @@ arguments, loops (for .. in), or for comprehensions."
                                 (-filter (lambda (token) (and (listp token) (eq (car token) '\,))) rest)))
                          (args-filtered (cons first-arg rest-args))
                          (params (-map (lambda (token)
-                                         (car (split-string (symbol-name token) "=")))
+                                         (car (split-string (symbol-name token) "[=:]")))
                                        args-filtered)))
                     (setq result (append params result)))))
             (wrong-type-argument nil))))


### PR DESCRIPTION
E.g. args in code like

    def func(a: int, b: str = None)