### PR TITLE
README.md: melpa domain is changed, fix the broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Color Identifiers is in [MELPA](https://github.com/milkypostman/melpa/pull/1416)
 ```lisp
 (package-initialize)
 (add-to-list 'package-archives
-             '("melpa" . "http://melpa.milkbox.net/packages/") t)
+             '("melpa" . "https://melpa.org/packages/") t)
 (package-refresh-contents)
 ```
 


### PR DESCRIPTION
Pinging melpa.milkbox.net says

    melpa.milkbox.net: Name or service not known

Looking at the official melpa documentation, they use the other domain
name, so let's use it too.
