### PR TITLE
color-identifiers-mode.el: don't run hooks manually

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -67,8 +67,7 @@
       (cancel-timer color-identifiers:timer))
     (setq color-identifiers:timer nil)
     (font-lock-remove-keywords nil '((color-identifiers:colorize . default)))
-    (ad-deactivate 'enable-theme)
-    (run-hooks 'color-identifiers-mode-hook))
+    (ad-deactivate 'enable-theme))
   (color-identifiers:refontify))
 
 ;;;###autoload


### PR DESCRIPTION
First of all, running the hook is automated by the `define-minor-mode`
macro. It creates the hook if it was not yet defined, and always automatically
runs it whenever the mode is enabled.

Second, the "else" branch where the

    (run-hooks 'color-identifiers-mode-hook))

code was located in my experiments was never ran. Not upon enabling the
mode, nor upon closing the buffer. I am not sure under what circumstance
it may run, tbh.