### PR TITLE
Add cuda-mode to modes-alist

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -194,7 +194,7 @@ For cc-mode support within color-identifiers-mode."
     (delete-dups result)
     result))
 
-(dolist (maj-mode '(c-mode c++-mode java-mode rust-mode rustic-mode meson-mode typescript-mode))
+(dolist (maj-mode '(c-mode c++-mode java-mode rust-mode rustic-mode meson-mode typescript-mode cuda-mode))
   (color-identifiers:set-declaration-scan-fn
    maj-mode 'color-identifiers:cc-mode-get-declarations)
   (add-to-list


### PR DESCRIPTION
This fixes #77

I tested it on my computer and it looks good with a cuda file.

To test it yourself, install `cuda-mode` and open a cuda file (ending in `.cu`).  Or just open a c++ file and put it in cuda-mode because c++ and CUDA have nearly identical syntax.