### PR TITLE
Tree-sitter support

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -311,7 +311,7 @@ For cc-mode support within color-identifiers-mode."
  'color-identifiers:modes-alist
  `(go-mode . (,color-identifiers:re-not-inside-class-access
               "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)"
-              (nil font-lock-variable-name-face))))
+              (nil font-lock-variable-name-face tree-sitter-hl-face:variable))))
 
 ;; Python
 (when (fboundp 'python-nav-forward-defun)

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -277,7 +277,9 @@ For cc-mode support within color-identifiers-mode."
 ;; Ruby
 (add-to-list
  'color-identifiers:modes-alist
- `(ruby-mode . (,color-identifiers:re-not-inside-class-access "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)" (nil))))
+ `(ruby-mode . (,color-identifiers:re-not-inside-class-access
+                "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)"
+                (nil tree-sitter-hl-face:variable))))
 
 ;; R
 (add-to-list

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -194,7 +194,7 @@ SCAN-FN."
  'color-identifiers:modes-alist
  `(scala-mode . (,color-identifiers:re-not-inside-class-access
                  "\\_<\\([[:lower:]]\\([_]??[[:lower:][:upper:]\\$0-9]+\\)*\\(_+[#:<=>@!%&*+/?\\\\^|~-]+\\|_\\)?\\)"
-                 (nil scala-font-lock:var-face font-lock-variable-name-face))))
+                 (nil scala-font-lock:var-face font-lock-variable-name-face tree-sitter-hl-face:variable))))
 
 ;; C/C++
 (defun color-identifiers:cc-mode-get-declarations ()


### PR DESCRIPTION
As upstream Emacs are discussing possibility of migrating to tree-sitter, I decided to see if color-identifiers mode I use daily supports it.

In this PR, first 2 commits are unrelated fixes. 3rd commit is a small optimization; the variable `color-identifiers:colorize-behavior` it adds will be used in later commits. And finally, last commits introduce tree-sitter support for various languages.

Tree-sitter currently also supports JS, but I see lots of js-related modes in color-identifers and I'm kinda lost which needs to have the `tree-sitter-hl-face:variable` declared. As I don't usually use JS, I left that to the next motivated person to fix.

Note: the tree-sitter changes I only tested in c-mode and python-mode. Any additional testing is more than welcome.