### PR TITLE
Add an ability to change recoloring delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,22 +37,23 @@ If you like it, enable it for all supported files by adding the following to you
 (add-hook 'after-init-hook 'global-color-identifiers-mode)
 ```
 
-## Extras
+## Configuration
 
-To make the variables stand out, you can turn off highlighting for all other keywords in supported modes using a code like:
-```lisp
-(defun myfunc-color-identifiers-mode-hook ()
-  (let ((faces '(font-lock-comment-face font-lock-comment-delimiter-face font-lock-constant-face font-lock-type-face font-lock-function-name-face font-lock-variable-name-face font-lock-keyword-face font-lock-string-face font-lock-builtin-face font-lock-preprocessor-face font-lock-warning-face font-lock-doc-face font-lock-negation-char-face font-lock-regexp-grouping-construct font-lock-regexp-grouping-backslash)))
-    (dolist (face faces)
-      (face-remap-add-relative face '((:foreground "" :weight normal :slant normal)))))
-  (face-remap-add-relative 'font-lock-keyword-face '((:weight bold)))
-  (face-remap-add-relative 'font-lock-comment-face '((:slant italic)))
-  (face-remap-add-relative 'font-lock-builtin-face '((:weight bold)))
-  (face-remap-add-relative 'font-lock-preprocessor-face '((:weight bold)))
-  (face-remap-add-relative 'font-lock-function-name-face '((:slant italic)))
-  (face-remap-add-relative 'font-lock-string-face '((:slant italic)))
-  (face-remap-add-relative 'font-lock-constant-face '((:weight bold))))
-(add-hook 'color-identifiers-mode-hook 'myfunc-color-identifiers-mode-hook)
-```
+* Recoloring delay: the time before recoloring newly appeared identifiers is `5` seconds by default. To change it e.g. to `2` seconds add to your config `(setq color-identifiers:recoloring-delay 2 )`
+* To make the variables stand out, you can turn off highlighting for all other keywords in supported modes using a code like:
+    ```lisp
+    (defun myfunc-color-identifiers-mode-hook ()
+      (let ((faces '(font-lock-comment-face font-lock-comment-delimiter-face font-lock-constant-face font-lock-type-face font-lock-function-name-face font-lock-variable-name-face font-lock-keyword-face font-lock-string-face font-lock-builtin-face font-lock-preprocessor-face font-lock-warning-face font-lock-doc-face font-lock-negation-char-face font-lock-regexp-grouping-construct font-lock-regexp-grouping-backslash)))
+        (dolist (face faces)
+          (face-remap-add-relative face '((:foreground "" :weight normal :slant normal)))))
+      (face-remap-add-relative 'font-lock-keyword-face '((:weight bold)))
+      (face-remap-add-relative 'font-lock-comment-face '((:slant italic)))
+      (face-remap-add-relative 'font-lock-builtin-face '((:weight bold)))
+      (face-remap-add-relative 'font-lock-preprocessor-face '((:weight bold)))
+      (face-remap-add-relative 'font-lock-function-name-face '((:slant italic)))
+      (face-remap-add-relative 'font-lock-string-face '((:slant italic)))
+      (face-remap-add-relative 'font-lock-constant-face '((:weight bold))))
+    (add-hook 'color-identifiers-mode-hook 'myfunc-color-identifiers-mode-hook)
+    ```
 
-![Other Keywords Dimmed](https://raw.github.com/ankurdave/color-identifiers-mode/gh-pages/dim-other-keywords.png)
+    ![Other Keywords Dimmed](https://raw.github.com/ankurdave/color-identifiers-mode/gh-pages/dim-other-keywords.png)

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -48,13 +48,16 @@
 (defvar color-identifiers:timer nil
   "Timer for running `color-identifiers:refresh'.")
 
+(defvar color-identifiers:recoloring-delay 5
+  "The delay before running `color-identifiers:refresh'.")
+
 (defun color-identifiers:enable-timer ()
   (if color-identifiers:timer
       ;; Someone set the timer. Activate in case we cancelled it.
       (unless (memq color-identifiers:timer timer-idle-list)
         (timer-activate-when-idle color-identifiers:timer))
     (setq color-identifiers:timer
-          (run-with-idle-timer 5 t 'color-identifiers:refresh)))
+          (run-with-idle-timer color-identifiers:recoloring-delay t 'color-identifiers:refresh)))
   )
 
 (defvar-local color-identifiers:colorize-behavior nil


### PR DESCRIPTION
As #27 mentions, there is no documented ability to change recoloring delay to e.g. `0`. Such variable sounds useful to have, so let's add that. With this PR there is a variable `color-identifiers:recoloring-delay` that may be set to any delay a user wants, including zero.

Fixes: https://github.com/ankurdave/color-identifiers-mode/issues/27
Fixes: https://github.com/ankurdave/color-identifiers-mode/issues/75