### PR TITLE
RFC: Decrease delay before recoloring to improve interactivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you like it, enable it for all supported files by adding the following to you
 
 ## Configuration
 
-* Recoloring delay: the time before recoloring newly appeared identifiers is `5` seconds by default. To change it e.g. to `2` seconds add to your config `(setq color-identifiers:recoloring-delay 2 )`
+* Recoloring delay: the time before recoloring newly appeared identifiers is `2` seconds by default. To change it e.g. to `1` second add to your config `(setq color-identifiers:recoloring-delay 1)`
 * To make the variables stand out, you can turn off highlighting for all other keywords in supported modes using a code like:
     ```lisp
     (defun myfunc-color-identifiers-mode-hook ()

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -48,7 +48,7 @@
 (defvar color-identifiers:timer nil
   "Timer for running `color-identifiers:refresh'.")
 
-(defvar color-identifiers:recoloring-delay 5
+(defvar color-identifiers:recoloring-delay 2
   "The delay before running `color-identifiers:refresh'.")
 
 (defun color-identifiers:enable-timer ()


### PR DESCRIPTION
I think, the default delay of 5 seconds is kinda too big. People sometimes even think the mode doesn't work because of  that *(see #27, #75)*.

In real world after adding a variable you want it to be colored as fast as possible. So how about increasing interactivity a bit by decreasing the delay down to 2 seconds?