### PR TITLE
Add support for typescript-ts-mode and tsx-ts-mode

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -221,7 +221,7 @@ For cc-mode support within color-identifiers-mode."
     (delete-dups result)
     result))
 
-(dolist (maj-mode '(c-mode c++-mode java-mode rust-mode rustic-mode meson-mode typescript-mode cuda-mode))
+(dolist (maj-mode '(c-mode c++-mode java-mode rust-mode rustic-mode meson-mode typescript-mode cuda-mode tsx-ts-mode typescript-ts-mode))
   (color-identifiers:set-declaration-scan-fn
    maj-mode 'color-identifiers:cc-mode-get-declarations)
   (add-to-list


### PR DESCRIPTION
As a side note, ts-based modes (mentioned above in particular) [will be supported by Emacs 29 release](https://blog.phundrak.com/emacs-29-what-can-we-expect/).

Screenshot with `tsx-ts-mode` enabled:

![image](https://user-images.githubusercontent.com/7935057/212525865-c884b602-0601-479c-8366-34270cfd7a26.png)

As a side note, support for non-tree-sitter typescript mode was added in https://github.com/ankurdave/color-identifiers-mode/pull/74/files , so that is covered since year 2020.

Fixes: https://github.com/ankurdave/color-identifiers-mode/issues/85