### PR TITLE
Use more lightweight cc-mode scanning function for js2-jsx-mode

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -256,6 +256,8 @@ For cc-mode support within color-identifiers-mode."
                   "\\_<\\([a-zA-Z_$]\\(?:\\s_\\|\\sw\\)*\\)"
                   (nil font-lock-variable-name-face js2-function-param))))
 
+(color-identifiers:set-declaration-scan-fn
+ 'js2-jsx-mode 'color-identifiers:cc-mode-get-declarations)
 (add-to-list
  'color-identifiers:modes-alist
  `(js2-jsx-mode . (,color-identifiers:re-not-inside-class-access


### PR DESCRIPTION
`scan-identifiers` isn't the best scan-fn (see also #94) as it moves not just through changed properties. Let's use the cc-mode one, which goes exclusively through face changes while searching for declared identifiers.

Fixes: https://github.com/ankurdave/color-identifiers-mode/issues/62