### PR TITLE
README.md: avoid warnings in face-remap example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you like it, enable it for all supported files by adding the following to you
     (defun myfunc-color-identifiers-mode-hook ()
       (let ((faces '(font-lock-comment-face font-lock-comment-delimiter-face font-lock-constant-face font-lock-type-face font-lock-function-name-face font-lock-variable-name-face font-lock-keyword-face font-lock-string-face font-lock-builtin-face font-lock-preprocessor-face font-lock-warning-face font-lock-doc-face font-lock-negation-char-face font-lock-regexp-grouping-construct font-lock-regexp-grouping-backslash)))
         (dolist (face faces)
-          (face-remap-add-relative face '((:foreground "" :weight normal :slant normal)))))
+          (face-remap-add-relative face '(:inherit default))))
       (face-remap-add-relative 'font-lock-keyword-face '((:weight bold)))
       (face-remap-add-relative 'font-lock-comment-face '((:slant italic)))
       (face-remap-add-relative 'font-lock-builtin-face '((:weight bold)))


### PR DESCRIPTION
Using it the way the example suggests will result in harmless warnings in *Messages* buffer, [described here](https://emacs.stackexchange.com/questions/35349/what-is-the-correct-way-to-unset-foreground-color).

    Unable to load color ""

As described on the same page, more correct way to drop unwanted highlight would be to inherit the default style in face-remap call.

As a side note, I've been using this "default style remap" for 2 years now with no problems.
