### PR TITLE
feat: Add highlighting for clojurescript files

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -537,6 +537,12 @@ incompatible with Emacs Lisp syntax, such as reader macros (#)."
                    "\\_<\\(\\(?:\\s_\\|\\sw\\)+\\)"
                    (nil))))
 
+(add-to-list
+ 'color-identifiers:modes-alist
+ `(clojurescript-mode . (""
+                         "\\_<\\(\\(?:\\s_\\|\\sw\\)+\\)"
+                         (nil))))
+
 (dolist (maj-mode '(tuareg-mode sml-mode))
   (color-identifiers:set-declaration-scan-fn
    maj-mode 'color-identifiers:cc-mode-get-declarations)


### PR DESCRIPTION
Why?:
- ClojureScript is the same as Clojure - syntax-wise. But ClojureScript has its own major mode in Emacs which is currently preventing color-identifiers-mode from working in .cljs files.

This change addresses the need by:
- Add clojurescript-mode to color-identifiers:modes-alist