### PR TITLE
Cleanups and improvements to elisp-mode declarations scanning

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -704,12 +704,13 @@ major mode, identifiers are saved to
   (when color-identifiers-mode
     (cond
      ((eq color-identifiers-coloring-method 'sequential)
-      (let ((i 0))
+      (let ((i 0)
+            ;; to make sure subsequently added vars aren't colorized the same add a (point)
+            (randomize-subseq-calls (point)))
         (dolist (identifier (color-identifiers:list-identifiers))
           (unless (gethash identifier color-identifiers:color-index-for-identifier)
             (puthash identifier
-                     ;; to make sure subsequently added vars aren't colorized the same add a (point)
-                     (% (+ (point) i) color-identifiers:num-colors)
+                     (% (+ randomize-subseq-calls i) color-identifiers:num-colors)
                      color-identifiers:color-index-for-identifier)
             (setq i (1+ i))))))
      ((and (eq color-identifiers-coloring-method 'hash)

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -383,7 +383,6 @@ For Emacs Lisp support within color-identifiers-mode."
                  (puthash (symbol-name arg)
                           t result))))
            (push rest stack))
-          (`nil nil)
           ((pred consp)
            (let ((cons current))
              ;; Note: a cons is not necessarily a list, so can't rewrite this with a

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -364,7 +364,7 @@ arguments, loops (for .. in), or for comprehensions."
   "Extract a list of identifiers declared in SEXP. Mutates SEXP.
 For Emacs Lisp support within color-identifiers-mode."
   (let ((stack `(,sexp)))
-    (while stack
+    (while (and stack (not (input-pending-p)))
       (let ((current (pop stack)))
         (pcase current
           ((or `(let . ,rest) `(let* . ,rest))

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -393,8 +393,7 @@ For Emacs Lisp support within color-identifiers-mode."
                (push (car cons) stack)
                (setq cons (cdr cons)))
              (when cons ;; `cons' is non-nil but also non-cons
-               (push cons stack)))))))
-    result))
+               (push cons stack)))))))))
 
 (defun color-identifiers:elisp-get-declarations ()
   "Extract a list of identifiers declared in the current buffer.

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -376,6 +376,10 @@ For Emacs Lisp support within color-identifiers-mode."
     ((pred consp)
      (let ((cons sexp)
            (result nil))
+       ;; Note: a cons is not necessarily a list, so can't rewrite this with a
+       ;; `dolist'. The difference is, a `(cdr cons)' of a list is required to either
+       ;; be another cons or `nil'. An example of the opposite is `(1 . 2)', the
+       ;; `dolist' will fail on that.
        (while (consp cons)
          (let ((ids (color-identifiers:elisp-declarations-in-sexp (car cons))))
            (when ids

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -361,10 +361,10 @@ arguments, loops (for .. in), or for comprehensions."
 
 ;; Emacs Lisp
 (defun color-identifiers:elisp-declarations-in-sexp (sexp)
-  "Extract a list of identifiers declared in SEXP.
+  "Extract a list of identifiers declared in SEXP. Mutates SEXP.
 For Emacs Lisp support within color-identifiers-mode."
   (let ((result nil)
-        (stack (list sexp)))
+        (stack `(,sexp)))
     (while stack
       (let ((current (pop stack)))
         (pcase current


### PR DESCRIPTION
Major changes:

1. It is transformed from a recursive version to iterative one
2. hash-tables are used now instead of a list
3. As the function is pretty heave since it needs to read the whole buffer, a check for whether input is pending was added