### PR TITLE
Alleviate slowness of parsing huge 20k+ lines python files

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -321,7 +321,7 @@ arguments, loops (for .. in), or for comprehensions."
     ;; Function arguments
     (save-excursion
       (goto-char (point-min))
-      (while (python-nav-forward-defun)
+      (while (and (python-nav-forward-defun) (not (input-pending-p)))
         (condition-case nil
             (let ((arglist (sexp-at-point)))
               (when (and arglist (listp arglist))


### PR DESCRIPTION
Do it by interrupting parsing if user is trying to do something.

See also: https://github.com/ankurdave/color-identifiers-mode/issues/103