### PR TITLE
Add rust-ts-mode as a recognized mode

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -210,7 +210,7 @@ SCAN-FN."
           (setq next-change (next-property-change (point))))))
     (hash-table-keys result)))
 
-(dolist (maj-mode '(c-mode c++-mode java-mode rust-mode rustic-mode meson-mode typescript-mode cuda-mode tsx-ts-mode typescript-ts-mode))
+(dolist (maj-mode '(c-mode c++-mode java-mode rust-mode rust-ts-mode rustic-mode meson-mode typescript-mode cuda-mode tsx-ts-mode typescript-ts-mode))
   (add-to-list
    'color-identifiers:modes-alist
    `(,maj-mode . (""


### PR DESCRIPTION
In the same vein as the other tree-sitter mode changes, e.g. #91.  Tested on emacs 30.0.50.