### PR TITLE
Don't call (font-lock-flush) unless font-lock-mode is enabled

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -730,9 +730,9 @@ major mode, identifiers are saved to
 
 (defun color-identifiers:refontify ()
   "Refontify the buffer using font-lock."
-  (if (fboundp 'font-lock-flush)
-      (font-lock-flush)
-    (when font-lock-mode
+  (when font-lock-mode
+    (if (fboundp 'font-lock-flush)
+        (font-lock-flush)
       (with-no-warnings
         (font-lock-fontify-buffer)))))
 


### PR DESCRIPTION
It's a no-op change as (font-lock-flush) was doing nothing with font-lock mode disabled anyway. But as we're checking for the mode, let's do so earlier.

I also grepped through local elpa dir, and other packages that do that kind of conditioning work similarly.