### PR TITLE
Support extra face properties on identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If you like it, enable it for all supported files by adding the following to you
 ## Configuration
 
 * Recoloring delay: the time before recoloring newly appeared identifiers is `2` seconds by default. To change it e.g. to `1` second add to your config `(setq color-identifiers:recoloring-delay 1)`
+* Additional face-properties *(such as italic or bold)* can be added to the identifiers by modifying `color-identifiers:extra-face-attributes`. E.g. to make identifiers look bold use `(setq color-identifiers:extra-face-attributes '(:weight bold))`. But make sure not to change `:foreground` because it is the color of identifiers.
 * To make the variables stand out, you can turn off highlighting for all other keywords in supported modes using a code like:
     ```lisp
     (defun myfunc-color-identifiers-mode-hook ()

--- a/build.ninja
+++ b/build.ninja
@@ -6,7 +6,12 @@ rule compile_file
   command = emacs -batch --eval "(setq byte-compile-error-on-warn t)" $args -f batch-byte-compile $in
 
 build dash.el: batch_emacs
-  args = --eval "(progn (require 'url) (url-copy-file \"https://raw.githubusercontent.com/magnars/dash.el/master/dash.el\" \"dash.el\"))"
+  # In the code below we remove dash.el manually, because when it's "dirty",
+  # url-copy-file won't overwrite it (it may ignore it but that's different).
+  args = --eval "(progn$
+                   (require 'url)$
+                   (delete-file \"dash.el\")$
+                   (url-copy-file \"https://raw.githubusercontent.com/magnars/dash.el/master/dash.el\" \"dash.el\"))"
 
 build color-identifiers-mode.elc: compile_file color-identifiers-mode.el | dash.el
   args = -l dash.el

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -88,6 +88,13 @@ color should be avoided when generating colors, this can be warning colors,
 error colors etc."
   :type '(repeat face))
 
+(defcustom color-identifiers:extra-face-attributes nil
+  "Extra face attributes to apply to identifiers. Can be used to make
+identifiers bold or italic, but avoid changing `:foreground'
+because it is the color determined by the mode."
+  :type 'plist
+  :group 'color-identifiers)
+
 (defvar color-identifiers:modes-alist nil
   "Alist of major modes and the ways to distinguish identifiers in those modes.
 The value of each cons cell provides four constraints for finding
@@ -803,9 +810,10 @@ evaluates to true."
      (let* ((identifier (buffer-substring-no-properties start end))
             (hex (color-identifiers:color-identifier identifier)))
        (when hex
-         (put-text-property start end 'face `(:foreground ,hex))
-         (put-text-property start end 'color-identifiers:fontified t))))
-   limit))
+         (let ((face-spec (append `(:foreground ,hex) color-identifiers:extra-face-attributes)))
+           (put-text-property start end 'face face-spec)
+           (put-text-property start end 'color-identifiers:fontified t)))))
+     limit))
 
 (defun color-identifiers-mode-maybe ()
   "Enable `color-identifiers-mode' in the current buffer if desired.


### PR DESCRIPTION
I've been always using the plugin with the faces being locally set to `:weight bold`, because to my eye identifiers with the default weight are harder to distinguish. I figure, it may be useful to other people, so decided to implement it in the code.