### PR TITLE
Rm extra indirection by making (color-identifiers:refontify) an alias

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -748,11 +748,11 @@ major mode, identifiers are saved to
 
 (defun color-identifiers:refontify ()
   "Refontify the buffer using font-lock."
-  (when font-lock-mode
-    (if (fboundp 'font-lock-flush)
-        (font-lock-flush)
-      (with-no-warnings
-        (font-lock-fontify-buffer)))))
+  (if (fboundp 'font-lock-flush)
+      (font-lock-flush)
+    ;; `font-lock-flush' didn't exist prior to Emacs 25.1
+    (with-no-warnings
+      (and font-lock-mode (font-lock-fontify-buffer)))))
 
 (defun color-identifiers:color-identifier (identifier)
   "Return the hex color for IDENTIFIER, or nil if it should not

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -7,7 +7,7 @@
 ;; Created: 24 Jan 2014
 ;; Version: 1.1
 ;; Keywords: faces, languages
-;; Package-Requires: ((dash "2.5.0") (emacs "24"))
+;; Package-Requires: ((dash "2.5.0") (emacs "24.4"))
 
 ;; This file is not a part of GNU Emacs.
 

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -746,13 +746,13 @@ major mode, identifiers are saved to
     ;; `color-identifiers:get-declarations', which returns all identifiers
     (color-identifiers:get-declarations)))
 
-(defun color-identifiers:refontify ()
-  "Refontify the buffer using font-lock."
+(defalias 'color-identifiers:refontify
   (if (fboundp 'font-lock-flush)
-      (font-lock-flush)
-    ;; `font-lock-flush' didn't exist prior to Emacs 25.1
-    (with-no-warnings
-      (and font-lock-mode (font-lock-fontify-buffer)))))
+      'font-lock-flush
+    (lambda ()
+      "Refontify the buffer using font-lock."
+      (with-no-warnings
+        (and font-lock-mode (font-lock-fontify-buffer))))))
 
 (defun color-identifiers:color-identifier (identifier)
   "Return the hex color for IDENTIFIER, or nil if it should not


### PR DESCRIPTION
For Emacs 25.1 and higher that makes `(color-identifiers:refontify)` an alias to
`(font-lock-flush)`. `(color-identifiers:refontify)` always was just a wrapper, so no
functional change is intended besides removing the unnecessary indirection.

I haven't found a way to just leave `(if (fboundp … (defalias …)` expression at the
top-level and not cause any byte-compilation errors, so the solution required a
little bit of hackery, but hopefully it should be safe. At least tests are passing
and I haven't found any problems.