### PR TITLE
Put face-spec and color-identifiers:fontfified with a single call

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -684,7 +684,7 @@ mode. This variable memoizes the result of the declaration scan function.")
   (color-identifiers:refontify))
 
 ;;;###autoload
-(define-global-minor-mode global-color-identifiers-mode
+(define-globalized-minor-mode global-color-identifiers-mode
   color-identifiers-mode color-identifiers-mode-maybe)
 
 (defun color-identifiers:attribute-luminance (attribute)

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -811,8 +811,7 @@ evaluates to true."
             (hex (color-identifiers:color-identifier identifier)))
        (when hex
          (let ((face-spec (append `(:foreground ,hex) color-identifiers:extra-face-attributes)))
-           (put-text-property start end 'face face-spec)
-           (put-text-property start end 'color-identifiers:fontified t)))))
+           (add-text-properties start end `(face ,face-spec color-identifiers:fontified t))))))
      limit))
 
 (defun color-identifiers-mode-maybe ()


### PR DESCRIPTION
This replaces two `put-text-property` calls with a single add-text-properties. I've been using this change with different programming languages for about an year locally, noticed no problem. So it should be fine.

The other commit is a trivial byte-compilation fix for upstream Emacs.