### PR TITLE
Don't skip highligting font-lock-variable-use-face

### DIFF
--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -684,7 +684,7 @@ mode. This variable memoizes the result of the declaration scan function.")
   (color-identifiers:refontify))
 
 ;;;###autoload
-(define-global-minor-mode global-color-identifiers-mode
+(define-globalized-minor-mode global-color-identifiers-mode
   color-identifiers-mode color-identifiers-mode-maybe)
 
 (defun color-identifiers:attribute-luminance (attribute)

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -777,10 +777,11 @@ be colored."
 
 (defun color-identifiers:scan-identifiers (fn limit)
   "Run FN on all candidate identifiers from point up to LIMIT.
-Candidate identifiers are defined by
-`color-identifiers:modes-alist'. Declaration scan functions are
-not applied. If supplied, iteration only continues if CONTINUE-P
-evaluates to true."
+
+Basically, this is the function that highlights all identifiers, with
+highlight being done by applying FN.
+
+Candidate identifiers are defined by `color-identifiers:modes-alist'."
   (let ((identifier-context-re (nth 1 color-identifiers:colorize-behavior))
         (identifier-re (nth 2 color-identifiers:colorize-behavior))
         (identifier-faces (color-identifiers:curr-identifier-faces))

--- a/color-identifiers-mode.el
+++ b/color-identifiers-mode.el
@@ -789,7 +789,16 @@ Candidate identifiers are defined by `color-identifiers:modes-alist'."
     ;; Skip forward to the next identifier that matches all four conditions
     (condition-case nil
         (while (< (point) limit)
-          (if (or (memq (get-text-property (point) 'face) identifier-faces)
+          (if (or (let ((curr-face (get-text-property (point) 'face)))
+                    (or
+                     ;; Note: if `curr-face' is nil, the memq will usually
+                     ;; succeed because nil is typically part of the list.
+                     (memq curr-face identifier-faces)
+                     ;; `font-lock-variable-use-face' isn't included in
+                     ;; `identifier-faces' due to the latter being also used for
+                     ;; initial scanning, so `font-lock-variable-use-face' being
+                     ;; there would be an overhead with no benefit.
+                     (eq curr-face 'font-lock-variable-use-face)))
                   (let ((flface-prop (get-text-property (point) 'font-lock-face)))
                     (and flface-prop (memq flface-prop identifier-faces))))
               (if (and (looking-back identifier-context-re (line-beginning-position))


### PR DESCRIPTION
typescript-ts-mode in master Emacs added support for highlighting some operations with identifiers via `font-lock-variable-use-face'. Before this commit color-identifiers-mode would mistakenly refuse to highlight these. Fix that by explicitly checking for the face while deciding if we want to highlight text at point.

There's also same commit for s/global/globalized minor-mode taken from https://github.com/ankurdave/color-identifiers-mode/pull/123, because without it CI wouldn't pass byte-compilation.
